### PR TITLE
feat(go-back-to-top): add floating button to scroll back to top

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -16,6 +16,7 @@ import { SessionsTracker } from '@/components/global/sessionsTrackers'
 import { ThemeProvider } from '@/components/providers/ThemeProvider'
 import { getClerkLocalization } from '@/lib/i18n/clerk/localization'
 import QueryProvider from '@/components/providers/QueryProvider'
+import { GoBackToTop } from '@/components/global/go-back-to-top'
 import SentryClientInit from '@/app/[locale]/SentryClientInit'
 import PageTransition from '@/components/ui/PageTransition'
 import { getVersion } from '@/lib/utils/version'
@@ -139,6 +140,7 @@ export default async function RootLayout(props: { params: Promise<LocaleParams>;
 									<CookieBanner />
 									<ConsentManagerDialog />
 									<Footer localeParams={props.params} />
+									<GoBackToTop locale={locale} />
 									<Toaster />
 								</NuqsAdapter>
 							</QueryProvider>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,7 +3,6 @@ import SecurityProcess from '@/components/landing/security-process/SecurityProce
 import JourneyTabs from '@/components/landing/journey-tabs/JourneyTabs'
 import HeroAlternative from '@/components/landing/hero/HeroAlternative'
 import FeaturesBento from '@/components/landing/features/Features'
-import { GoBackToTop } from '@/components/global/go-back-to-top'
 // import BibStats from '@/components/landing/bib-stats/BibStats'
 import BesWibCTA from '@/components/landing/cta/CTASection'
 // import Hero from '@/components/landing/hero/Hero'
@@ -15,7 +14,7 @@ export function generateStaticParams() {
 
 export default async function Home({ params }: { params: Promise<LocaleParams> }) {
 	// Locale will be used when components are updated for i18n 🗺️
-	const { locale } = await params
+	await params
 
 	return (
 		<div className="relative">
@@ -32,9 +31,6 @@ export default async function Home({ params }: { params: Promise<LocaleParams> }
 			<SecurityProcess localeParams={params} />
 			{/* CTA Section 📣 */}
 			<BesWibCTA localeParams={params} />
-
-			{/* Go Back to Top Button 🔝 */}
-			<GoBackToTop locale={locale} />
 		</div>
 	)
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,6 +3,7 @@ import SecurityProcess from '@/components/landing/security-process/SecurityProce
 import JourneyTabs from '@/components/landing/journey-tabs/JourneyTabs'
 import HeroAlternative from '@/components/landing/hero/HeroAlternative'
 import FeaturesBento from '@/components/landing/features/Features'
+import { GoBackToTop } from '@/components/global/go-back-to-top'
 // import BibStats from '@/components/landing/bib-stats/BibStats'
 import BesWibCTA from '@/components/landing/cta/CTASection'
 // import Hero from '@/components/landing/hero/Hero'
@@ -14,7 +15,7 @@ export function generateStaticParams() {
 
 export default async function Home({ params }: { params: Promise<LocaleParams> }) {
 	// Locale will be used when components are updated for i18n 🗺️
-	await params
+	const { locale } = await params
 
 	return (
 		<div className="relative">
@@ -31,6 +32,9 @@ export default async function Home({ params }: { params: Promise<LocaleParams> }
 			<SecurityProcess localeParams={params} />
 			{/* CTA Section 📣 */}
 			<BesWibCTA localeParams={params} />
+
+			{/* Go Back to Top Button 🔝 */}
+			<GoBackToTop locale={locale} />
 		</div>
 	)
 }

--- a/src/components/global/go-back-to-top.tsx
+++ b/src/components/global/go-back-to-top.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ArrowUp } from 'lucide-react'
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -18,81 +18,130 @@ interface GoBackToTopProps {
 	locale: Locale
 	/**
 	 * Scroll threshold in pixels. When the user scrolls past this point,
-	 * the button becomes visible. Default is 300px.
+	 * the button becomes visible. Default is 100px.
 	 */
 	threshold?: number
 	/**
 	 * Additional CSS classes to apply to the button container
 	 */
 	className?: string
+	/**
+	 * Show immediately when user starts scrolling (even before threshold)
+	 */
+	showOnScroll?: boolean
 }
 
 /**
  * A floating "go back to top" button that appears when the user scrolls down.
  * Features:
- * - Only visible after scrolling past a threshold
- * - Smooth scroll animation to top
+ * - Only visible after scrolling past a threshold or immediately when scrolling starts
+ * - Smooth scroll animation to top with optimized performance
  * - Tooltip with translated text
- * - Responsive design
+ * - Responsive design with improved mobile experience
  * - Accessible with keyboard navigation
  * - Automatic internationalization
+ * - Throttled scroll events for better performance
+ * - Smooth fade-in/out animations
  */
-export function GoBackToTop({ threshold = 300, locale, className }: GoBackToTopProps) {
+export function GoBackToTop({ threshold = 100, showOnScroll = true, locale, className }: GoBackToTopProps) {
 	const [isVisible, setIsVisible] = useState(false)
+	const [isAnimating, setIsAnimating] = useState(false)
 
 	// Get translations for the current locale
 	const t = getTranslations(locale, translations)
 
-	useEffect(() => {
-		const toggleVisibility = () => {
-			if (window.scrollY > threshold) {
-				setIsVisible(true)
-			} else {
-				setIsVisible(false)
+	// Throttle function to improve scroll performance
+	const throttle = useCallback(<T extends unknown[]>(func: (...args: T) => void, limit: number) => {
+		let inThrottle: boolean
+		return function (...args: T) {
+			if (!inThrottle) {
+				func(...args)
+				inThrottle = true
+				setTimeout(() => (inThrottle = false), limit)
 			}
 		}
+	}, [])
 
-		// Add scroll event listener
-		window.addEventListener('scroll', toggleVisibility)
+	const toggleVisibility = useCallback(() => {
+		const scrolled = window.scrollY
+		const shouldShow = showOnScroll ? scrolled > 10 : scrolled > threshold
+
+		if (shouldShow && !isVisible) {
+			setIsVisible(true)
+		} else if (!shouldShow && isVisible) {
+			setIsVisible(false)
+		}
+	}, [threshold, showOnScroll, isVisible])
+
+	// Create throttled version of toggleVisibility
+	const throttledToggleVisibility = useCallback(throttle(toggleVisibility, 100), [toggleVisibility, throttle])
+
+	useEffect(() => {
+		// Add scroll event listener with throttling
+		window.addEventListener('scroll', throttledToggleVisibility, { passive: true })
+
+		// Check initial scroll position
+		toggleVisibility()
 
 		// Clean up the event listener on component unmount
 		return () => {
-			window.removeEventListener('scroll', toggleVisibility)
+			window.removeEventListener('scroll', throttledToggleVisibility)
 		}
-	}, [threshold])
+	}, [throttledToggleVisibility, toggleVisibility])
 
-	const scrollToTop = () => {
+	const scrollToTop = useCallback(() => {
+		setIsAnimating(true)
+
 		window.scrollTo({
 			top: 0,
 			behavior: 'smooth',
 		})
-	}
 
-	if (!isVisible) {
-		return null
-	}
+		// Reset animation state after scroll completes
+		setTimeout(() => {
+			setIsAnimating(false)
+		}, 800)
+	}, [])
 
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<Button
-					onClick={scrollToTop}
-					size="icon"
-					variant="outline"
-					className={cn(
-						'fixed right-6 bottom-6 z-50 h-12 w-12 rounded-full shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-xl',
-						'bg-background/80 border-border/50 backdrop-blur-sm',
-						'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2',
-						className
-					)}
-					aria-label={t.goBackToTop}
-				>
-					<ArrowUp className="h-5 w-5" />
-				</Button>
-			</TooltipTrigger>
-			<TooltipContent side="left" sideOffset={10}>
-				<p className="text-sm font-medium">{t.goBackToTop}</p>
-			</TooltipContent>
-		</Tooltip>
+		<>
+			{isVisible && (
+				<div className="fixed right-4 bottom-4 z-[999999] sm:right-6 sm:bottom-6">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								onClick={scrollToTop}
+								size="icon"
+								variant="outline"
+								disabled={isAnimating}
+								className={cn(
+									'h-11 w-11 rounded-full shadow-lg transition-all duration-300',
+									'sm:h-12 sm:w-12',
+									'bg-background/90 border-border/60 backdrop-blur-md',
+									'hover:bg-background/95 hover:scale-110 hover:shadow-xl',
+									'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2',
+									'active:scale-95',
+									isAnimating && 'animate-pulse',
+									'dark:bg-background/95 dark:border-border/40',
+									className
+								)}
+								aria-label={t.goBackToTop}
+							>
+								<ArrowUp
+									className={cn(
+										'h-4 w-4 transition-transform duration-200',
+										'sm:h-5 sm:w-5',
+										isAnimating && 'scale-90'
+									)}
+								/>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="left" sideOffset={12} className="hidden sm:block">
+							<p className="text-sm font-medium">{t.goBackToTop}</p>
+						</TooltipContent>
+					</Tooltip>
+				</div>
+			)}
+		</>
 	)
 }

--- a/src/components/global/go-back-to-top.tsx
+++ b/src/components/global/go-back-to-top.tsx
@@ -111,7 +111,7 @@ export function GoBackToTop({
 			if (window.scrollY === 0) {
 				setIsAnimating(false)
 				window.removeEventListener('scroll', handleScroll)
-				if (fallbackTimeoutId != null) clearTimeout(fallbackTimeoutId)
+				if (fallbackTimeoutId != null) window.clearTimeout(fallbackTimeoutId)
 			}
 		}
 		window.addEventListener('scroll', handleScroll, { passive: true })

--- a/src/components/global/go-back-to-top.tsx
+++ b/src/components/global/go-back-to-top.tsx
@@ -78,7 +78,7 @@ export function GoBackToTop({
 		const scrolled = window.scrollY
 		// Hide strictly when back at the very top; otherwise apply threshold logic
 		const shouldShow = showOnScroll ? scrolled > 0 : scrolled > threshold
-		setIsVisible(prev => (prev !== shouldShow ? shouldShow : prev))
+		setIsVisible(shouldShow)
 	}, [threshold, showOnScroll])
 
 	// Create throttled version of toggleVisibility (animation-frame throttled)

--- a/src/components/global/go-back-to-top.tsx
+++ b/src/components/global/go-back-to-top.tsx
@@ -111,7 +111,7 @@ export function GoBackToTop({
 			if (window.scrollY === 0) {
 				setIsAnimating(false)
 				window.removeEventListener('scroll', handleScroll)
-				if (fallbackTimeoutId) clearTimeout(fallbackTimeoutId)
+				if (fallbackTimeoutId != null) clearTimeout(fallbackTimeoutId)
 			}
 		}
 		window.addEventListener('scroll', handleScroll, { passive: true })

--- a/src/components/global/go-back-to-top.tsx
+++ b/src/components/global/go-back-to-top.tsx
@@ -119,7 +119,7 @@ export function GoBackToTop({
 		fallbackTimeoutId = window.setTimeout(() => {
 			setIsAnimating(false)
 			window.removeEventListener('scroll', handleScroll)
-		}, animationResetTimeoutMs) as number
+		}, animationResetTimeoutMs)
 	}, [animationResetTimeoutMs])
 
 	return (

--- a/src/components/global/go-back-to-top.tsx
+++ b/src/components/global/go-back-to-top.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ArrowUp } from 'lucide-react'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { getTranslations } from '@/lib/i18n/dictionary'
+import { Button } from '@/components/ui/button'
+import { Locale } from '@/lib/i18n/config'
+import { cn } from '@/lib/utils'
+
+import translations from './locales.json'
+
+interface GoBackToTopProps {
+	/**
+	 * Current locale for translation
+	 */
+	locale: Locale
+	/**
+	 * Scroll threshold in pixels. When the user scrolls past this point,
+	 * the button becomes visible. Default is 300px.
+	 */
+	threshold?: number
+	/**
+	 * Additional CSS classes to apply to the button container
+	 */
+	className?: string
+}
+
+/**
+ * A floating "go back to top" button that appears when the user scrolls down.
+ * Features:
+ * - Only visible after scrolling past a threshold
+ * - Smooth scroll animation to top
+ * - Tooltip with translated text
+ * - Responsive design
+ * - Accessible with keyboard navigation
+ * - Automatic internationalization
+ */
+export function GoBackToTop({ threshold = 300, locale, className }: GoBackToTopProps) {
+	const [isVisible, setIsVisible] = useState(false)
+
+	// Get translations for the current locale
+	const t = getTranslations(locale, translations)
+
+	useEffect(() => {
+		const toggleVisibility = () => {
+			if (window.scrollY > threshold) {
+				setIsVisible(true)
+			} else {
+				setIsVisible(false)
+			}
+		}
+
+		// Add scroll event listener
+		window.addEventListener('scroll', toggleVisibility)
+
+		// Clean up the event listener on component unmount
+		return () => {
+			window.removeEventListener('scroll', toggleVisibility)
+		}
+	}, [threshold])
+
+	const scrollToTop = () => {
+		window.scrollTo({
+			top: 0,
+			behavior: 'smooth',
+		})
+	}
+
+	if (!isVisible) {
+		return null
+	}
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					onClick={scrollToTop}
+					size="icon"
+					variant="outline"
+					className={cn(
+						'fixed right-6 bottom-6 z-50 h-12 w-12 rounded-full shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-xl',
+						'bg-background/80 border-border/50 backdrop-blur-sm',
+						'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2',
+						className
+					)}
+					aria-label={t.goBackToTop}
+				>
+					<ArrowUp className="h-5 w-5" />
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="left" sideOffset={10}>
+				<p className="text-sm font-medium">{t.goBackToTop}</p>
+			</TooltipContent>
+		</Tooltip>
+	)
+}

--- a/src/components/global/go-back-to-top.tsx
+++ b/src/components/global/go-back-to-top.tsx
@@ -119,7 +119,7 @@ export function GoBackToTop({
 		fallbackTimeoutId = window.setTimeout(() => {
 			setIsAnimating(false)
 			window.removeEventListener('scroll', handleScroll)
-		}, animationResetTimeoutMs)
+		}, animationResetTimeoutMs) as number
 	}, [animationResetTimeoutMs])
 
 	return (

--- a/src/components/global/locales.json
+++ b/src/components/global/locales.json
@@ -93,7 +93,8 @@
 				"messageResponse": "We'll get back to you as soon as possible.",
 				"sendAnotherMessage": "Send another message"
 			}
-		}
+		},
+		"goBackToTop": "Go back to top of the page"
 	},
 	"fr": {
 		"navbar": {
@@ -189,7 +190,8 @@
 				"messageResponse": "Nous vous répondrons dès que possible.",
 				"sendAnotherMessage": "Envoyer un autre message"
 			}
-		}
+		},
+		"goBackToTop": "Retour en haut de la page"
 	},
 	"es": {
 		"navbar": {
@@ -285,7 +287,8 @@
 				"messageResponse": "Te responderemos lo antes posible.",
 				"sendAnotherMessage": "Enviar otro mensaje"
 			}
-		}
+		},
+		"goBackToTop": "Volver al principio de la página"
 	},
 	"it": {
 		"navbar": {
@@ -381,7 +384,8 @@
 				"messageResponse": "Ti risponderemo al più presto.",
 				"sendAnotherMessage": "Invia un altro messaggio"
 			}
-		}
+		},
+		"goBackToTop": "Torna all'inizio della pagina"
 	},
 	"de": {
 		"navbar": {
@@ -477,7 +481,8 @@
 				"messageResponse": "Wir melden uns so schnell wie möglich.",
 				"sendAnotherMessage": "Weitere Nachricht senden"
 			}
-		}
+		},
+		"goBackToTop": "Zurück zum Seitenanfang"
 	},
 	"ro": {
 		"navbar": {
@@ -573,7 +578,8 @@
 				"messageResponse": "Îți vom răspunde cât mai curând.",
 				"sendAnotherMessage": "Trimite un alt mesaj"
 			}
-		}
+		},
+		"goBackToTop": "Înapoi în partea de sus a paginii"
 	},
 	"pt": {
 		"navbar": {
@@ -669,7 +675,8 @@
 				"messageResponse": "Responderemos o mais rapidamente possível.",
 				"sendAnotherMessage": "Enviar outra mensagem"
 			}
-		}
+		},
+		"goBackToTop": "Voltar ao topo da página"
 	},
 	"nl": {
 		"navbar": {
@@ -765,7 +772,8 @@
 				"messageResponse": "We reageren zo snel mogelijk.",
 				"sendAnotherMessage": "Nog een bericht sturen"
 			}
-		}
+		},
+		"goBackToTop": "Terug naar boven"
 	},
 	"ko": {
 		"navbar": {
@@ -861,6 +869,7 @@
 				"messageResponse": "최대한 빨리 답변해 드리겠습니다.",
 				"sendAnotherMessage": "다른 메시지 보내기"
 			}
-		}
+		},
+		"goBackToTop": "페이지 상단으로 이동"
 	}
 }


### PR DESCRIPTION
This pull request introduces a new internationalized "Go Back to Top" floating button component to the application layout, enhancing user navigation and accessibility. The button appears when the user scrolls down, supports smooth scrolling, and displays a tooltip translated to the current locale. The implementation includes performance optimizations and updates translations for all supported languages.

**New "Go Back to Top" feature:**

* Added the `GoBackToTop` component, which provides a floating button for users to quickly scroll back to the top of the page. The component features smooth scrolling, fade-in/out animations, accessibility improvements, and performance-optimized scroll event handling. (`src/components/global/go-back-to-top.tsx`)
* Integrated the `GoBackToTop` button into the main application layout so it appears on all pages, passing the current locale for proper internationalization. (`src/app/[locale]/layout.tsx`) ([src/app/[locale]/layout.tsxR19](diffhunk://#diff-d387de9ed27220b8f151f3debc731746f2804b3e509aa2f99de6d40137df203aR19), [src/app/[locale]/layout.tsxR143](diffhunk://#diff-d387de9ed27220b8f151f3debc731746f2804b3e509aa2f99de6d40137df203aR143))

**Localization updates:**

* Added `goBackToTop` translations for all supported languages in the `locales.json` file, ensuring the tooltip and accessibility label are localized. (`src/components/global/locales.json`) [[1]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L96-R97) [[2]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L192-R194) [[3]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L288-R291) [[4]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L384-R388) [[5]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L480-R485) [[6]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L576-R582) [[7]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L672-R679) [[8]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L768-R776) [[9]](diffhunk://#diff-a484062e8c0d757f4fcc12ab2fb3bb178fb5f0e3356adc7690197d341462f628L864-R873)