### PR TITLE
feat(address-autocomplete): implement address autocomplete feature

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -80,6 +80,7 @@ const nextConfig: NextConfig = {
 			'https://*.beswib.com',
 			'https://clerk.beswib.com',
 			'https://*.paypal.com',
+			'https://nominatim.openstreetmap.org',
 		].join(' ')
 
 		const frameSrc = [

--- a/src/components/profile/modernRunnerForm.tsx
+++ b/src/components/profile/modernRunnerForm.tsx
@@ -13,9 +13,9 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import profileTranslations from '@/components/profile/locales.json'
 import { updateUserProfile } from '@/app/[locale]/profile/actions'
 import { isUserProfileComplete } from '@/lib/validation/user'
+import { AddressInput } from '@/components/ui/address-input'
 import { formatDateForHTMLInput } from '@/lib/utils/date'
 import { getTranslations } from '@/lib/i18n/dictionary'
-import { AddressInput } from '@/components/ui/address-input'
 import { Input } from '@/components/ui/inputAlt'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
@@ -387,9 +387,9 @@ export default function ModernRunnerForm({ user, locale = 'en' as Locale }: Read
 								value={form.watch('address')}
 								onChange={value => form.setValue('address', value)}
 								otherFields={{
-									city: form.watch('city'),
-									country: form.watch('country'),
 									postalCode: form.watch('postalCode'),
+									country: form.watch('country'),
+									city: form.watch('city'),
 								}}
 								onAddressSelect={components => {
 									// Auto-fill ALL fields when user selects an address

--- a/src/components/profile/modernRunnerForm.tsx
+++ b/src/components/profile/modernRunnerForm.tsx
@@ -15,6 +15,7 @@ import { updateUserProfile } from '@/app/[locale]/profile/actions'
 import { isUserProfileComplete } from '@/lib/validation/user'
 import { formatDateForHTMLInput } from '@/lib/utils/date'
 import { getTranslations } from '@/lib/i18n/dictionary'
+import { AddressInput } from '@/components/ui/address-input'
 import { Input } from '@/components/ui/inputAlt'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
@@ -379,12 +380,35 @@ export default function ModernRunnerForm({ user, locale = 'en' as Locale }: Read
 							<Label className="text-foreground mb-2 block text-base font-medium" htmlFor="address">
 								{t.street ?? 'Street Address'} *
 							</Label>
-							<Input
-								{...form.register('address')}
+							<AddressInput
 								className={form.formState.errors.address ? 'border-red-500' : ''}
 								id="address"
 								placeholder="123 Main Street"
-								type="text"
+								value={form.watch('address')}
+								onChange={value => form.setValue('address', value)}
+								otherFields={{
+									city: form.watch('city'),
+									country: form.watch('country'),
+									postalCode: form.watch('postalCode'),
+								}}
+								onAddressSelect={components => {
+									// Auto-fill ALL fields when user selects an address
+									// Always fill street address (this is the main input)
+									if (components.street && components.street.trim() !== '') {
+										form.setValue('address', components.street)
+									}
+
+									// Fill other fields if they're empty OR if they don't match what's already there
+									if (components.city && components.city.trim() !== '') {
+										form.setValue('city', components.city)
+									}
+									if (components.postalCode && components.postalCode.trim() !== '') {
+										form.setValue('postalCode', components.postalCode)
+									}
+									if (components.country && components.country.trim() !== '') {
+										form.setValue('country', components.country)
+									}
+								}}
 							/>
 							{form.formState.errors.address && (
 								<p className="mt-1 text-sm text-red-600 dark:text-red-400">{form.formState.errors.address.message}</p>

--- a/src/components/profile/modernRunnerForm.tsx
+++ b/src/components/profile/modernRunnerForm.tsx
@@ -398,15 +398,31 @@ export default function ModernRunnerForm({ user, locale = 'en' as Locale }: Read
 										form.setValue('address', components.street)
 									}
 
-									// Fill other fields if they're empty OR if they don't match what's already there
+									// Smart fill: only update other fields if they're empty or significantly different
+									const currentCity = form.getValues('city')?.trim() ?? ''
+									const currentPostalCode = form.getValues('postalCode')?.trim() ?? ''
+									const currentCountry = form.getValues('country')?.trim() ?? ''
+
+									// Fill city if empty or if it's very different from the suggested one
 									if (components.city && components.city.trim() !== '') {
-										form.setValue('city', components.city)
+										const suggestedCity = components.city.trim()
+										if (!currentCity?.toLowerCase().includes(suggestedCity.toLowerCase())) {
+											form.setValue('city', suggestedCity)
+										}
 									}
+
+									// Fill postal code if empty or different
 									if (components.postalCode && components.postalCode.trim() !== '') {
-										form.setValue('postalCode', components.postalCode)
+										if (!currentPostalCode || currentPostalCode !== components.postalCode.trim()) {
+											form.setValue('postalCode', components.postalCode)
+										}
 									}
+
+									// Fill country if empty or different
 									if (components.country && components.country.trim() !== '') {
-										form.setValue('country', components.country)
+										if (!currentCountry || currentCountry !== components.country.trim()) {
+											form.setValue('country', components.country)
+										}
 									}
 								}}
 							/>

--- a/src/components/ui/address-input.tsx
+++ b/src/components/ui/address-input.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { forwardRef, useEffect, useRef } from 'react'
+import { ChevronDown, MapPin } from 'lucide-react'
+
+import { useAddressAutocomplete } from '@/hooks/useAddressAutocomplete'
+
+import { extractAddressComponents, formatAddressDisplay, type NominatimResult } from '@/lib/utils/nominatim'
+import { Input } from '@/components/ui/inputAlt'
+import { cn } from '@/lib/utils'
+
+interface AddressInputProps {
+	/** The current address value */
+	value: string
+	/** Callback when address changes */
+	onChange: (value: string) => void
+	/** Callback when address is selected from suggestions */
+	onAddressSelect?: (components: { city: string; country: string; postalCode: string; street: string }) => void
+	/** Placeholder text */
+	placeholder?: string
+	/** Additional CSS classes */
+	className?: string
+	/** Whether the input has an error */
+	hasError?: boolean
+	/** Input ID */
+	id?: string
+	/** Input name */
+	name?: string
+	/** Current values of other address fields - used to determine if dropdown should auto-close */
+	otherFields?: {
+		city?: string
+		country?: string
+		postalCode?: string
+	}
+}
+
+/**
+ * Address input component with autocomplete suggestions from Nominatim API
+ * Shows dropdown after 3+ words and 1 second delay
+ */
+export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
+	({ value, placeholder, otherFields, onChange, onAddressSelect, name, id, hasError, className, ...props }, ref) => {
+		const containerRef = useRef<HTMLDivElement>(null)
+		const {
+			suggestions,
+			showSuggestionsDropdown,
+			showSuggestions,
+			setQuery,
+			selectSuggestion,
+			query,
+			isLoading,
+			hideSuggestions,
+		} = useAddressAutocomplete({
+			minLength: 3,
+			maxResults: 5,
+			debounceMs: 1000,
+		})
+
+		// Sync with external value
+		useEffect(() => {
+			if (value !== query) {
+				setQuery(value)
+			}
+		}, [value, query, setQuery])
+
+		// Check if other address fields are already completed
+		const areOtherFieldsComplete = () => {
+			if (!otherFields) return false
+
+			const { postalCode, country, city } = otherFields
+			return !!(
+				city != null &&
+				city.trim() !== '' &&
+				country != null &&
+				country.trim() !== '' &&
+				postalCode != null &&
+				postalCode.trim() !== ''
+			)
+		}
+
+		// Handle clicks outside to close dropdown
+		useEffect(() => {
+			const handleClickOutside = (event: MouseEvent) => {
+				if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+					hideSuggestions()
+				}
+			}
+
+			document.addEventListener('mousedown', handleClickOutside)
+			return () => {
+				document.removeEventListener('mousedown', handleClickOutside)
+			}
+		}, [hideSuggestions])
+
+		// Also prevent showing suggestions on focus if other fields are complete
+		const shouldShowSuggestions = () => {
+			return !areOtherFieldsComplete() && suggestions.length > 0
+		}
+
+		// Auto-close dropdown if other fields are already complete
+		useEffect(() => {
+			if (areOtherFieldsComplete() && showSuggestions) {
+				hideSuggestions()
+			}
+		}, [otherFields, showSuggestions, hideSuggestions])
+
+		const handleInputChange = (newValue: string) => {
+			setQuery(newValue)
+			onChange(newValue)
+		}
+
+		const handleSuggestionSelect = (suggestion: NominatimResult) => {
+			const components = extractAddressComponents(suggestion)
+
+			// Use the extracted street address instead of the full display name
+			const streetAddress = components.street || formatAddressDisplay(suggestion)
+			onChange(streetAddress)
+			setQuery(streetAddress)
+
+			// Notify parent component with structured data
+			onAddressSelect?.(components)
+
+			// Hide suggestions
+			selectSuggestion(suggestion)
+		}
+
+		const handleInputFocus = () => {
+			// Only show suggestions if other fields are not already complete
+			if (shouldShowSuggestions()) {
+				showSuggestionsDropdown()
+			}
+		}
+
+		const handleKeyDown = (event: React.KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				hideSuggestions()
+			}
+		}
+
+		return (
+			<div className="relative" ref={containerRef}>
+				<div className="relative">
+					<Input
+						{...props}
+						ref={ref}
+						className={cn('pr-8', hasError === true && 'border-red-500', isLoading && 'pr-16', className)}
+						id={id}
+						name={name}
+						placeholder={placeholder}
+						value={query}
+						onChange={e => handleInputChange(e.target.value)}
+						onFocus={handleInputFocus}
+						onKeyDown={handleKeyDown}
+					/>
+
+					{/* Loading indicator */}
+					{isLoading && (
+						<div className="absolute top-1/2 right-3 -translate-y-1/2">
+							<div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+						</div>
+					)}
+
+					{/* Dropdown indicator */}
+					{!isLoading && suggestions.length > 0 && (
+						<ChevronDown
+							className={cn(
+								'absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 text-gray-400 transition-transform',
+								showSuggestions && 'rotate-180'
+							)}
+						/>
+					)}
+				</div>
+
+				{/* Suggestions dropdown */}
+				{shouldShowSuggestions() && showSuggestions && (
+					<div className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border bg-white py-1 shadow-lg dark:bg-gray-800">
+						{suggestions.map(suggestion => (
+							<button
+								key={suggestion.place_id}
+								className="flex w-full items-start gap-2 px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+								type="button"
+								onClick={() => handleSuggestionSelect(suggestion)}
+							>
+								<MapPin className="mt-0.5 h-4 w-4 flex-shrink-0 text-gray-400" />
+								<div className="min-w-0 flex-1">
+									<div className="truncate font-medium text-gray-900 dark:text-gray-100">{suggestion.display_name}</div>
+									{suggestion.address.country != null && suggestion.address.country.trim() !== '' && (
+										<div className="text-xs text-gray-500 dark:text-gray-400">{suggestion.address.country}</div>
+									)}
+								</div>
+							</button>
+						))}
+					</div>
+				)}
+			</div>
+		)
+	}
+)
+
+AddressInput.displayName = 'AddressInput'

--- a/src/components/ui/address-input.tsx
+++ b/src/components/ui/address-input.tsx
@@ -51,17 +51,18 @@ export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
 			isLoading,
 			hideSuggestions,
 		} = useAddressAutocomplete({
+			minWords: 3, // Require at least 3 words for better address matching
 			minLength: 3,
 			maxResults: 5,
 			debounceMs: 1000,
 		})
 
-		// Sync with external value
+		// Sync with external value - but avoid triggering if we just set it ourselves
 		useEffect(() => {
 			if (value !== query) {
 				setQuery(value)
 			}
-		}, [value, query, setQuery])
+		}, [value, setQuery]) // Remove query from deps to avoid circular updates
 
 		// Check if other address fields are already completed
 		const areOtherFieldsComplete = () => {
@@ -114,8 +115,10 @@ export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
 
 			// Use the extracted street address instead of the full display name
 			const streetAddress = components.street || formatAddressDisplay(suggestion)
-			onChange(streetAddress)
+
+			// Update both query and parent value in a controlled way to avoid race conditions
 			setQuery(streetAddress)
+			onChange(streetAddress)
 
 			// Notify parent component with structured data
 			onAddressSelect?.(components)

--- a/src/constants/api.constant.ts
+++ b/src/constants/api.constant.ts
@@ -1,0 +1,1 @@
+export const NOMINATIM_API_URL = 'https://nominatim.openstreetmap.org/search'

--- a/src/hooks/useAddressAutocomplete.ts
+++ b/src/hooks/useAddressAutocomplete.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { type NominatimResult, searchAddresses } from '@/lib/utils/nominatim'
+
+interface UseAddressAutocompleteOptions {
+	/** Minimum number of characters before triggering search */
+	minLength?: number
+	/** Debounce delay in milliseconds */
+	debounceMs?: number
+	/** Maximum number of results to show */
+	maxResults?: number
+}
+
+interface UseAddressAutocompleteReturn {
+	/** Current search query */
+	query: string
+	/** Array of address suggestions */
+	suggestions: NominatimResult[]
+	/** Whether a search is currently in progress */
+	isLoading: boolean
+	/** Whether the suggestions dropdown should be shown */
+	showSuggestions: boolean
+	/** Update the search query */
+	setQuery: (query: string) => void
+	/** Select a suggestion and hide the dropdown */
+	selectSuggestion: (suggestion: NominatimResult) => void
+	/** Hide the suggestions dropdown */
+	hideSuggestions: () => void
+	/** Show the suggestions dropdown */
+	showSuggestionsDropdown: () => void
+	/** Clear all suggestions */
+	clearSuggestions: () => void
+}
+
+/**
+ * Hook for address autocomplete using Nominatim API
+ * Includes debouncing and rate limiting to be respectful to the API
+ */
+export function useAddressAutocomplete(options: UseAddressAutocompleteOptions = {}): UseAddressAutocompleteReturn {
+	const { minLength = 3, maxResults = 5, debounceMs = 1000 } = options
+
+	const [isLoading, setIsLoading] = useState(false)
+	const [query, setQuery] = useState('')
+	const [showSuggestions, setShowSuggestions] = useState(false)
+	const [suggestions, setSuggestions] = useState<NominatimResult[]>([])
+
+	const debounceRef = useRef<NodeJS.Timeout | null>(null)
+	const lastRequestRef = useRef<string>('')
+
+	const searchAddressesDebounced = useCallback(
+		async (searchQuery: string) => {
+			// Avoid duplicate requests
+			if (searchQuery === lastRequestRef.current) {
+				return
+			}
+
+			// Check minimum length
+			if (searchQuery.trim().length < minLength) {
+				setSuggestions([])
+				setIsLoading(false)
+				return
+			}
+
+			// Check if query has at least 3 words (as requested)
+			const wordCount = searchQuery.trim().split(/\s+/).length
+			if (wordCount < 3) {
+				setSuggestions([])
+				setIsLoading(false)
+				return
+			}
+
+			lastRequestRef.current = searchQuery
+			setIsLoading(true)
+
+			try {
+				const results = await searchAddresses(searchQuery)
+
+				// Only update if this is still the current query
+				if (searchQuery === lastRequestRef.current) {
+					setSuggestions(results.slice(0, maxResults))
+					setShowSuggestions(results.length > 0)
+				}
+			} catch (error) {
+				console.warn('Address search failed:', error)
+				if (searchQuery === lastRequestRef.current) {
+					setSuggestions([])
+					setShowSuggestions(false)
+				}
+			} finally {
+				if (searchQuery === lastRequestRef.current) {
+					setIsLoading(false)
+				}
+			}
+		},
+		[maxResults, minLength]
+	)
+
+	// Debounced search effect
+	useEffect(() => {
+		// Clear existing timeout
+		if (debounceRef.current) {
+			clearTimeout(debounceRef.current)
+		}
+
+		// Set new timeout
+		debounceRef.current = setTimeout(() => {
+			void searchAddressesDebounced(query)
+		}, debounceMs)
+
+		// Cleanup on unmount
+		return () => {
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current)
+			}
+		}
+	}, [debounceMs, query, searchAddressesDebounced])
+
+	const selectSuggestion = useCallback((suggestion: NominatimResult) => {
+		// This callback can be used by parent components to handle selection
+		// For now, we just clear the internal state
+		setQuery('')
+		setSuggestions([])
+		setShowSuggestions(false)
+		lastRequestRef.current = ''
+
+		// Note: The actual suggestion handling is done in the AddressInput component
+		// This callback is primarily for clearing state
+		console.debug('Address suggestion selected:', suggestion.display_name)
+	}, [])
+
+	const hideSuggestions = useCallback(() => {
+		setShowSuggestions(false)
+	}, [])
+
+	const showSuggestionsDropdown = useCallback(() => {
+		if (suggestions.length > 0) {
+			setShowSuggestions(true)
+		}
+	}, [suggestions.length])
+
+	const clearSuggestions = useCallback(() => {
+		setSuggestions([])
+		setShowSuggestions(false)
+		lastRequestRef.current = ''
+	}, [])
+
+	return {
+		suggestions,
+		showSuggestionsDropdown,
+		showSuggestions,
+		setQuery,
+		selectSuggestion,
+		query,
+		isLoading,
+		hideSuggestions,
+		clearSuggestions,
+	}
+}

--- a/src/lib/utils/nominatim.ts
+++ b/src/lib/utils/nominatim.ts
@@ -1,3 +1,5 @@
+import { NOMINATIM_API_URL } from '@/constants/api.constant'
+
 export interface NominatimAddress {
 	house_number?: string
 	road?: string
@@ -51,14 +53,11 @@ export async function searchAddresses(query: string): Promise<NominatimResult[]>
 
 	try {
 		const encodedQuery = encodeURIComponent(query.trim())
-		const response = await fetch(
-			`https://nominatim.openstreetmap.org/search?q=${encodedQuery}&format=json&addressdetails=1&limit=5`,
-			{
-				headers: {
-					'User-Agent': 'Beswib-App/1.0 (https://beswib.com)',
-				},
-			}
-		)
+		const response = await fetch(`${NOMINATIM_API_URL}?q=${encodedQuery}&format=json&addressdetails=1&limit=5`, {
+			headers: {
+				'User-Agent': 'Beswib-App/1.0 (https://beswib.com)',
+			},
+		})
 
 		if (!response.ok) {
 			console.warn('Nominatim API error:', response.status, response.statusText)

--- a/src/lib/utils/nominatim.ts
+++ b/src/lib/utils/nominatim.ts
@@ -1,0 +1,117 @@
+export interface NominatimAddress {
+	house_number?: string
+	road?: string
+	neighbourhood?: string
+	suburb?: string
+	city?: string
+	municipality?: string
+	county?: string
+	state?: string
+	region?: string
+	postcode?: string
+	country?: string
+	country_code?: string
+}
+
+export interface NominatimResult {
+	place_id: number
+	licence: string
+	osm_type: string
+	osm_id: number
+	lat: string
+	lon: string
+	class: string
+	type: string
+	place_rank: number
+	importance: number
+	addresstype: string
+	name: string
+	display_name: string
+	address: NominatimAddress
+	boundingbox: [string, string, string, string]
+}
+
+/**
+ * Search for addresses using the Nominatim API
+ *
+ * IMPORTANT: This API is rate limited and should be used sparingly
+ * - Only triggers for queries with 3+ words
+ * - Includes 1 second debounce delay
+ * - Limits to 5 results maximum
+ * - Includes proper User-Agent header
+ * - Gracefully handles errors without breaking the app
+ *
+ * @param query - The address search query
+ * @returns Promise<NominatimResult[]> - Array of address results
+ */
+export async function searchAddresses(query: string): Promise<NominatimResult[]> {
+	if (!query || query.trim().length < 3) {
+		return []
+	}
+
+	try {
+		const encodedQuery = encodeURIComponent(query.trim())
+		const response = await fetch(
+			`https://nominatim.openstreetmap.org/search?q=${encodedQuery}&format=json&addressdetails=1&limit=5`,
+			{
+				headers: {
+					'User-Agent': 'Beswib-App/1.0 (https://beswib.com)',
+				},
+			}
+		)
+
+		if (!response.ok) {
+			console.warn('Nominatim API error:', response.status, response.statusText)
+			return []
+		}
+
+		const data = (await response.json()) as unknown
+		return Array.isArray(data) ? (data as NominatimResult[]) : []
+	} catch (error) {
+		console.warn('Failed to fetch address suggestions:', error)
+		return []
+	}
+}
+
+/**
+ * Format a Nominatim result for display
+ */
+export function formatAddressDisplay(result: NominatimResult): string {
+	return result.display_name
+}
+
+/**
+ * Extract structured address components from a Nominatim result
+ */
+export function extractAddressComponents(result: NominatimResult) {
+	const { address } = result
+
+	// Build the street address from house number and road
+	let street = ''
+	if (
+		address.house_number != null &&
+		address.house_number.trim() !== '' &&
+		address.road != null &&
+		address.road.trim() !== ''
+	) {
+		street = `${address.house_number} ${address.road}`.trim()
+	} else if (address.road != null && address.road.trim() !== '') {
+		street = address.road.trim()
+	}
+
+	// Use the full display name as fallback for street if no specific road found
+	if (street === '' && result.display_name != null && result.display_name.trim() !== '') {
+		// Extract the first part of display_name which usually contains the street
+		const parts = result.display_name.split(', ')
+		if (parts.length > 0) {
+			street = parts[0]
+		}
+	}
+
+	return {
+		street,
+		postalCode: address.postcode ?? '',
+		country: address.country ?? '',
+		city: address.city ?? address.municipality ?? address.suburb ?? '',
+	}
+}


### PR DESCRIPTION
This pull request introduces an address autocomplete feature for user profiles, leveraging the Nominatim API to provide structured address suggestions and autofill capabilities. The main changes include a new `AddressInput` component, a supporting hook for autocomplete logic, utility functions for Nominatim integration, and updates to the profile form to use these enhancements.

**Address Autocomplete Feature:**

* Added a new `AddressInput` component with autocomplete suggestions, dropdown UI, and auto-filling of address fields based on user selection. (`src/components/ui/address-input.tsx`)
* Implemented the `useAddressAutocomplete` hook to handle debounced API requests, dropdown state, and suggestion management for address search. (`src/hooks/useAddressAutocomplete.ts`)
* Created utility functions for searching addresses, formatting display, and extracting structured address components from Nominatim results. (`src/lib/utils/nominatim.ts`)
* Updated the profile form to use `AddressInput` instead of a plain input for addresses, enabling auto-population of street, city, country, and postal code fields when an address is selected. (`src/components/profile/modernRunnerForm.tsx`) [[1]](diffhunk://#diff-c9c96b0bee9dbfaf2c5b15d23860f725073133901357e5944118efd48482002cR16) [[2]](diffhunk://#diff-c9c96b0bee9dbfaf2c5b15d23860f725073133901357e5944118efd48482002cL382-R411)

**Configuration Update:**

* Allowed requests to the Nominatim API by adding its domain to the Next.js configuration's allowed sources. (`next.config.ts`)