### PR TITLE
feat(paypal): implement consent revoked handling

### DIFF
--- a/src/services/user.services.ts
+++ b/src/services/user.services.ts
@@ -150,6 +150,37 @@ export async function fetchUserByEmail(email: string): Promise<null | User> {
 	}
 }
 
+/**
+ * Fetch a user by their linked PayPal merchant ID
+ */
+export async function fetchUserByMerchantId(merchantId: string): Promise<null | User> {
+	if (merchantId == null || merchantId.trim() === '') {
+		console.error('merchantId is required to fetch user by PayPal merchant ID')
+		return null
+	}
+	try {
+		const user = await pb
+			.collection('users')
+			.getFirstListItem<PbUserRecordMinimal>(`paypalMerchantId = "${merchantId.trim()}"`)
+		if (user == null) {
+			return null
+		}
+		return mapPbRecordToUser(user)
+	} catch (error) {
+		// If no user found (404), return null - this is expected behavior
+		if (
+			error != null &&
+			typeof error === 'object' &&
+			'status' in error &&
+			(error as { status?: number }).status === 404
+		) {
+			return null
+		}
+		console.error('Error fetching user by PayPal merchant ID:', error)
+		return null
+	}
+}
+
 export async function fetchUserById(id: string): Promise<null | User> {
 	if (id === '') {
 		console.error('User ID (PocketBase record ID) is required to fetch user data.')


### PR DESCRIPTION
This pull request enhances the handling of PayPal consent revocation events and adds support for fetching users by their PayPal merchant ID. The main improvements focus on correctly unlinking users from revoked merchant IDs, robust error handling, and ensuring the user database remains consistent.

**PayPal Consent Revocation Handling:**

* Updated `handleConsentRevoked` in `paypal.services.ts` to properly process consent revocation events: checks for a valid `merchant_id`, fetches the associated user, unlinks the merchant ID, and resets the KYC flag. Includes detailed logging and error handling for missing or unknown merchant IDs.

**User Lookup Enhancements:**

* Added new `fetchUserByMerchantId` function in `user.services.ts` to retrieve a user by their PayPal merchant ID, with input validation and handling for not-found cases and errors.